### PR TITLE
Update CI and add a Release workflow

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch: false
+
+comment:
+  layout: "diff"
+  require_changes: true

--- a/.craft.yml
+++ b/.craft.yml
@@ -1,0 +1,15 @@
+minVersion: "1.8.1"
+github:
+  owner: getsentry
+  repo: pdb
+changelogPolicy: auto
+
+statusProvider:
+  name: github
+artifactProvider:
+  name: none
+
+preReleaseCommand: bash scripts/bump-version.sh
+targets:
+  - name: github
+  - name: crates

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[Makefile]
+indent_style = tab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,69 +2,76 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches:
+      - master
+      - "release/**"
   pull_request:
-    branches: [master]
 
 env:
-  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Dwarnings
 
 jobs:
-  lint:
-    name: Lint
+  lints:
+    name: Style/Linting
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          components: clippy, rustfmt, rust-docs
-          override: true
+      - run: rustup toolchain install stable --profile minimal --component rustfmt --component clippy --no-self-update
+      - uses: Swatinem/rust-cache@v2
 
-      - uses: swatinem/rust-cache@v1
+      - run: cargo fmt --all -- --check
+      - run: cargo clippy --all-features --workspace --tests --examples -- -D clippy::all
 
-      - name: Run Rustfmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+  doc-comments:
+    name: Documentation
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -Dwarnings
+    steps:
+      - uses: actions/checkout@v4
 
-      - name: Run Clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets --all-features -- -D warnings
+      - run: rustup toolchain install stable --profile minimal --component rust-docs --no-self-update
+      - uses: Swatinem/rust-cache@v2
 
-      - name: Rust Doc Comments
-        uses: actions-rs/cargo@v1
-        env:
-          RUSTDOCFLAGS: -Dwarnings
-        with:
-          command: doc
-          args: --no-deps --document-private-items
+      - run: cargo doc --workspace --all-features --document-private-items --no-deps
 
   test:
-    name: Test
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    name: Tests on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: rustup toolchain install stable --profile minimal --no-self-update
+      - uses: Swatinem/rust-cache@v2
+
+      - run: scripts/download
+
+      - run: cargo test --workspace --all-features --all-targets
+      - run: cargo test --workspace --all-features --doc
+
+  codecov:
+    name: Code Coverage
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions-rs/toolchain@v1
+      - run: rustup toolchain install stable --profile minimal --component llvm-tools-preview --no-self-update
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@cargo-llvm-cov
+
+      - run: scripts/download
+
+      - run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+
+      - uses: codecov/codecov-action@v3
         with:
-          toolchain: stable
-          profile: minimal
-          override: true
-
-      - uses: swatinem/rust-cache@v1
-
-      - name: Download Fixtures
-        run: scripts/download
-
-      - name: Run Cargo Tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+          files: lcov.info

--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -1,0 +1,16 @@
+name: Enforce License Compliance
+
+on:
+  push:
+    branches: [master, release/*]
+  pull_request:
+    branches: [master]
+
+jobs:
+  enforce-license-compliance:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Enforce License Compliance"
+        uses: getsentry/action-enforce-license-compliance@main
+        with:
+          fossa_api_key: ${{ secrets.FOSSA_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to release
+        required: false
+      force:
+        description: Force a release even when there are release-blockers (optional)
+        required: false
+      merge_target:
+        description: Target branch to merge into. Uses the default branch as a fallback (optional)
+        required: false
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: "Release a new version"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Fetch all commits so we can determine previous version
+          fetch-depth: 0
+          token: ${{ secrets.GH_RELEASE_PAT }}
+      - name: Prepare release
+        uses: getsentry/action-prepare-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
+        with:
+          version: ${{ github.event.inputs.version }}
+          force: ${{ github.event.inputs.force }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,0 +1,31 @@
+name: Weekly CI
+
+on:
+  schedule:
+    - cron: "14 3 * * 5" # every friday at 03:14
+  workflow_dispatch:
+
+env:
+  RUSTFLAGS: -Dwarnings
+
+jobs:
+  weekly-ci:
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: [nightly, beta]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: |
+          rustup toolchain install ${{ matrix.rust }} --profile minimal --component clippy --no-self-update
+          rustup default ${{ matrix.rust }}
+
+      - uses: arduino/setup-protoc@v3
+
+      - run: cargo clippy --all-features --workspace --tests --examples -- -D clippy::all
+      - run: cargo test --workspace --all-features --all-targets
+      - run: cargo test --workspace --all-features --doc

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target
 *.iml
 .idea
+.DS_Store
 
 fixtures/symbol_server/*

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -eux
+
+if [ "$(uname -s)" != "Linux" ]; then
+   echo "Please use the GitHub Action."
+   exit 1
+fi
+
+SCRIPT_DIR="$( dirname "$0" )"
+cd $SCRIPT_DIR/..
+
+OLD_VERSION="${1}"
+NEW_VERSION="${2}"
+
+echo "Current version: $OLD_VERSION"
+echo "Bumping version: $NEW_VERSION"
+
+function replace() {
+    ! grep "$2" $3
+    perl -i -pe "s/$1/$2/g" $3
+    grep "$2" $3  # verify that replacement was successful
+}
+
+replace "^version = \"[0-9.]+\"" "version = \"$NEW_VERSION\"" Cargo.toml
+cargo metadata --format-version 1 > /dev/null # update `Cargo.lock`


### PR DESCRIPTION
This pretty much copy-pastes the "newest" version of the generic CI workflow running the various tests, code coverage, etc.

It also adds the Sentry standard release workflow and craft definitions as well.
NOTE to self: I need to add this to `publish` as well to have it auto-approved.