### PR TITLE
chore: setup semgrepignore

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,7 @@
+# Ignore git items
+.git/
+.gitignore
+:include .gitignore
+
+examples/
+tests/


### PR DESCRIPTION
Ignores the `examples/` and `tests/` directories (along with anything in `.gitignore`) to reduce finding noise.